### PR TITLE
Add AxonFramework migration recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,13 +14,16 @@ dependencies {
 
     runtimeOnly("org.openrewrite:rewrite-java")
     runtimeOnly("org.openrewrite:rewrite-templating:${rewriteVersion}")
+
+    runtimeOnly("org.axonframework:axon-migration:latest.release")
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java")
     testImplementation("org.openrewrite:rewrite-test")
-    testImplementation("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
 
+    testImplementation("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
+
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")
 }
@@ -28,6 +31,7 @@ dependencies {
 tasks.withType<ShadowJar> {
     archiveClassifier.set("")
     dependencies {
+        include(dependency("org.axonframework:axon-migration"))
         include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
     }
 }

--- a/src/main/resources/META-INF/rewrite/category.yml
+++ b/src/main/resources/META-INF/rewrite/category.yml
@@ -30,3 +30,10 @@ description: |
   [Error Prone Support](https://github.com/PicnicSupermarket/error-prone-support) is a Picnic-opinionated extension of Google's [Error Prone](https://github.com/google/error-prone).
   It aims to improve code quality, focussing on maintainability, consistency and avoidance of common pitfalls.
 ---
+type: specs.openrewrite.org/v1beta/category
+name: Axon Framework
+packageName: org.axonframework
+root: true
+description: |
+  The [Axon Framework](https://axoniq.io/) is a Java framework for building high-performance, high-reliability applications with a focus on CQRS and Event Sourcing patterns.
+---


### PR DESCRIPTION
These are maintained externally (by me) Apache licensed there as well, and now included here to make them available synced to OpenRewrite releases more easily, and available through Moderne.