### PR TITLE
Add quarkus-update-recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,14 +17,12 @@ dependencies {
 
     runtimeOnly("ai.timefold.solver:timefold-solver-migration:latest.release")
     runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release")
-    runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release:core")
     runtimeOnly("org.axonframework:axon-migration:latest.release")
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java")
     testImplementation("org.openrewrite:rewrite-test")
 
-    testImplementation("io.quarkus:quarkus-update-recipes:latest.release")
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
@@ -36,8 +34,7 @@ tasks.withType<ShadowJar> {
     archiveClassifier.set("")
     dependencies {
         include(dependency("ai.timefold.solver:timefold-solver-migration"))
-        include(dependency("io.quarkus:quarkus-update-recipes:latest.release"))
-        include(dependency("io.quarkus:quarkus-update-recipes:latest.release:core"))
+        include(dependency("io.quarkus:quarkus-update-recipes:.*"))
         include(dependency("org.axonframework:axon-migration"))
         include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
     }
@@ -45,4 +42,5 @@ tasks.withType<ShadowJar> {
     exclude("**/*.refaster")
     // Redeclares existing Quarkus and OpenRewrite recipes
     exclude("**/ToLatest9.yml")
+    relocate("quarkus-updates", "META-INF.rewrite")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,12 +15,14 @@ dependencies {
     runtimeOnly("org.openrewrite:rewrite-java")
     runtimeOnly("org.openrewrite:rewrite-templating:${rewriteVersion}")
 
+    runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release")
     runtimeOnly("org.axonframework:axon-migration:latest.release")
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java")
     testImplementation("org.openrewrite:rewrite-test")
 
+    testImplementation("io.quarkus:quarkus-update-recipes:latest.release")
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
@@ -31,6 +33,7 @@ dependencies {
 tasks.withType<ShadowJar> {
     archiveClassifier.set("")
     dependencies {
+        include(dependency("io.quarkus:quarkus-update-recipes:latest.release"))
         include(dependency("org.axonframework:axon-migration"))
         include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
     runtimeOnly("ai.timefold.solver:timefold-solver-migration:latest.release")
     runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release")
+    runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release:core")
     runtimeOnly("org.axonframework:axon-migration:latest.release")
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
 
@@ -36,6 +37,7 @@ tasks.withType<ShadowJar> {
     dependencies {
         include(dependency("ai.timefold.solver:timefold-solver-migration"))
         include(dependency("io.quarkus:quarkus-update-recipes:latest.release"))
+        include(dependency("io.quarkus:quarkus-update-recipes:latest.release:core"))
         include(dependency("org.axonframework:axon-migration"))
         include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
     }

--- a/src/main/resources/META-INF/rewrite/category.yml
+++ b/src/main/resources/META-INF/rewrite/category.yml
@@ -23,6 +23,14 @@ description: |
   Timefold is a fork of OptaPlanner by its creator and other experts.
 ---
 type: specs.openrewrite.org/v1beta/category
+name: Quarkus
+packageName: io.quarkus.updates
+root: true
+description: |
+  [Quarkus](https://quarkus.io/) is a Cloud Native, (Linux) Container First framework for writing Java applications.
+  The [quarkus-updates](https://github.com/quarkusio/quarkus-updates) repository contains the recipes used to update Quarkus projects to newer versions.
+---
+type: specs.openrewrite.org/v1beta/category
 name: Axon Framework
 packageName: org.axonframework
 root: true


### PR DESCRIPTION
Adds quarkus-update-recipes

We likely still need to rename and move the `.yaml` files to fall under `/META-INF/rewrite` and end with `.yml`.
Look at https://imperceptiblethoughts.com/shadow/configuration/merging/#merging-service-descriptor-files

As by default the yaml resources are not immediately in the typical location.
![image](https://github.com/openrewrite/rewrite-third-party/assets/1027334/3363957e-d959-4823-b6f1-c9063dbd465d)
