### PR TITLE
Adopt error-prone-contrib:0.18.0:recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release")
     runtimeOnly("org.apache.wicket:wicket-migration:latest.release")
     runtimeOnly("org.axonframework:axon-migration:latest.release")
-    runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
+    runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes")
 
     // error-prone-contrib only has provided dependencies, whereas the platform needs these on the classpath at runtime
     runtimeOnly("org.junit.jupiter:junit-jupiter-api:latest.release")
@@ -39,13 +39,14 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-java")
     testImplementation("org.openrewrite:rewrite-test")
 
-    testImplementation("tech.picnic.error-prone-support:error-prone-contrib:latest.release")
+    testImplementation("tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")
 }
 
+// ./gradlew shadowJar
 tasks.withType<ShadowJar> {
     archiveClassifier.set("")
     dependencies {
@@ -53,12 +54,8 @@ tasks.withType<ShadowJar> {
         include(dependency("io.quarkus:quarkus-update-recipes:.*"))
         include(dependency("org.apache.wicket:wicket-migration"))
         include(dependency("org.axonframework:axon-migration"))
-        include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
+        include(dependency("tech.picnic.error-prone-support:error-prone-contrib:recipes"))
     }
-    // Binary files for ErrorProne; not needed for recipes
-    exclude("**/*.refaster")
-    exclude("**/*Rules.class")
-    exclude("**/bugpatterns/")
     // Redeclares existing Quarkus and OpenRewrite recipes
     exclude("**/ToLatest9.yml")
     relocate("quarkus-updates", "META-INF.rewrite")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ tasks.withType<ShadowJar> {
         include(dependency("io.quarkus:quarkus-update-recipes:.*"))
         include(dependency("org.apache.wicket:wicket-migration"))
         include(dependency("org.axonframework:axon-migration"))
-        include(dependency("tech.picnic.error-prone-support:error-prone-contrib:recipes"))
+        include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
     }
     // Redeclares existing Quarkus and OpenRewrite recipes
     exclude("**/ToLatest9.yml")


### PR DESCRIPTION
## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-third-party/issues/11

## Anything in particular you'd like reviewers to focus on?
Somehow right now the shadowJar does not contain the tech/ recipes. 😕 

## Have you considered any alternatives or workarounds?
Folks can add their own dependency on `tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes`.
But that would then not be released together with every OpenRewrite release, leading to mismatched versions used.

## Any additional context
- https://github.com/PicnicSupermarket/error-prone-support/releases/tag/v0.18.0
- https://github.com/PicnicSupermarket/error-prone-support/pull/1270
- https://github.com/openrewrite/rewrite-third-party/issues/11