### PR TITLE
Addressing Vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,10 @@ dependencies {
     runtimeOnly("ai.timefold.solver:timefold-solver-migration:latest.release") {
         exclude(module = "jakarta.xml.bind-api")
     }
-    runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release")
-    runtimeOnly("org.apache.camel.upgrade:camel-upgrade-recipes:latest.release")
-    runtimeOnly("org.apache.wicket:wicket-migration:latest.release")
-    runtimeOnly("org.axonframework:axon-migration:latest.release")
+    runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release") {isTransitive = false}
+    runtimeOnly("org.apache.camel.upgrade:camel-upgrade-recipes:latest.release") {isTransitive = false}
+    runtimeOnly("org.apache.wicket:wicket-migration:latest.release") {isTransitive = false}
+    runtimeOnly("org.axonframework:axon-migration:latest.release") {isTransitive = false}
     runtimeOnly("software.amazon.awssdk:v2-migration:latest.release")
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes")
 


### PR DESCRIPTION
We are pulling in rewrite-jenkins@17 which has the following CVEs: CVE-2022-34793, CVE-2022-34792, CVE-2022-34794

This is just a runtimeDependency so we have the option of ignoring it, as it's an easy fix to remove I remove it instead of suppressing it