### PR TITLE
Limit how far back chained Quarkus migrations run

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-java")
     testImplementation("org.openrewrite:rewrite-test")
 
+    testImplementation("org.openrewrite:rewrite-maven")
+
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.14.2")
     testImplementation("org.junit-pioneer:junit-pioneer:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,7 @@ dependencies {
     }
 
     testImplementation("org.openrewrite:rewrite-java")
-    testImplementation("org.openrewrite:rewrite-maven")
     testImplementation("org.openrewrite:rewrite-test")
-    testImplementation("org.openrewrite.recipe:rewrite-java-dependencies:${rewriteVersion}")
 
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.14.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,9 @@ dependencies {
     }
 
     testImplementation("org.openrewrite:rewrite-java")
-    testImplementation("org.openrewrite:rewrite-maven")
     testImplementation("org.openrewrite:rewrite-test")
+
+    testCompileOnly("org.openrewrite:rewrite-maven")
 
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.14.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     }
 
     testImplementation("org.openrewrite:rewrite-java")
+    testImplementation("org.openrewrite:rewrite-maven")
     testImplementation("org.openrewrite:rewrite-test")
 
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,8 +44,6 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-java")
     testImplementation("org.openrewrite:rewrite-test")
 
-    testCompileOnly("org.openrewrite:rewrite-maven")
-
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.14.2")
     testImplementation("org.junit-pioneer:junit-pioneer:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,9 @@ dependencies {
     }
 
     testImplementation("org.openrewrite:rewrite-java")
+    testImplementation("org.openrewrite:rewrite-maven")
     testImplementation("org.openrewrite:rewrite-test")
+    testImplementation("org.openrewrite.recipe:rewrite-java-dependencies:${rewriteVersion}")
 
     testImplementation("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.14.2")

--- a/src/main/resources/META-INF/rewrite/quarkus-consolidated.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-consolidated.yml
@@ -20,6 +20,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0
 displayName: Quarkus Updates Aggregate 3.0.0
 description: Quarkus update recipes to upgrade your application to 3.0.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.0.0)
 recipeList:
   - io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe
   - org.openrewrite.java.camel.migrate.removedExtensions
@@ -78,6 +83,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_1_0
 displayName: Quarkus Updates Aggregate 3.1.0
 description: Quarkus update recipes to upgrade your application to 3.1.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.1.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0
   - io.quarkus.updates.core.quarkus31.RemoveMockitoInline
@@ -87,6 +97,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_2_0
 displayName: Quarkus Updates Aggregate 3.2.0
 description: Quarkus update recipes to upgrade your application to 3.2.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.2.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_1_0
   - io.quarkus.updates.core.quarkus32.InjectMock
@@ -98,6 +113,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_3_0
 displayName: Quarkus Updates Aggregate 3.3.0
 description: Quarkus update recipes to upgrade your application to 3.3.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.3.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_2_0
   - io.quarkus.updates.core.quarkus33.ApplicationProperties
@@ -109,6 +129,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_5_0
 displayName: Quarkus Updates Aggregate 3.5.0
 description: Quarkus update recipes to upgrade your application to 3.5.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.5.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_3_0
   - io.quarkus.updates.core.quarkus35.MutinyUniAndGroupCombinedWith
@@ -119,6 +144,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_6_0
 displayName: Quarkus Updates Aggregate 3.6.0
 description: Quarkus update recipes to upgrade your application to 3.6.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.6.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_5_0
   - io.quarkus.updates.core.quarkus36.JaegerSmallRyeOpenTracing
@@ -128,6 +158,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_7_0
 displayName: Quarkus Updates Aggregate 3.7.0
 description: Quarkus update recipes to upgrade your application to 3.7.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.7.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_6_0
   - io.quarkus.updates.core.quarkus37.HibernateSearchOutboxPolling
@@ -150,6 +185,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_8_0
 displayName: Quarkus Updates Aggregate 3.8.0
 description: Quarkus update recipes to upgrade your application to 3.8.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.8.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_7_0
   - io.quarkus.updates.camel.camel44.CamelQuarkusMigrationRecipe
@@ -161,6 +201,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_8_3
 displayName: Quarkus Updates Aggregate 3.8.3
 description: Quarkus update recipes to upgrade your application to 3.8.3.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.8.3)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_8_0
   - io.quarkus.updates.core.quarkus383.GraalSDK
@@ -170,6 +215,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_9_0
 displayName: Quarkus Updates Aggregate 3.9.0
 description: Quarkus update recipes to upgrade your application to 3.9.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.9.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_8_3
   - io.quarkus.updates.core.quarkus39.RemovePanacheAnnotationProcessor
@@ -183,6 +233,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_10_0
 displayName: Quarkus Updates Aggregate 3.10.0
 description: Quarkus update recipes to upgrade your application to 3.10.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.10.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_9_0
   - io.quarkus.updates.core.quarkus310.SyncHibernateJpaModelgenVersionWithBOM
@@ -203,6 +258,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_11_0
 displayName: Quarkus Updates Aggregate 3.11.0
 description: Quarkus update recipes to upgrade your application to 3.11.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.11.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_10_0
   - io.quarkus.updates.core.quarkus311.SyncHibernateJpaModelgenVersionWithBOM
@@ -212,6 +272,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_12_0
 displayName: Quarkus Updates Aggregate 3.12.0
 description: Quarkus update recipes to upgrade your application to 3.12.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.12.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_11_0
   - io.quarkus.updates.core.quarkus312.SyncHibernateJpaModelgenVersionWithBOM
@@ -221,6 +286,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_13_0
 displayName: Quarkus Updates Aggregate 3.13.0
 description: Quarkus update recipes to upgrade your application to 3.13.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.13.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_12_0
   - io.quarkus.updates.core.quarkus313.SyncHibernateJpaModelgenVersionWithBOM
@@ -231,6 +301,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_15_0
 displayName: Quarkus Updates Aggregate 3.15.0
 description: Quarkus update recipes to upgrade your application to 3.15.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.15.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_13_0
   - io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe
@@ -240,6 +315,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_17_0
 displayName: Quarkus Updates Aggregate 3.17.0
 description: Quarkus update recipes to upgrade your application to 3.17.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.17.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_15_0
   - io.quarkus.updates.camel.camel49.CamelQuarkusMigrationRecipe
@@ -249,6 +329,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_18_0
 displayName: Quarkus Updates Aggregate 3.18.0
 description: Quarkus update recipes to upgrade your application to 3.18.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.18.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_17_0
   - io.quarkus.updates.core.quarkus318.RemoveFlywayCleanOnValidationError
@@ -259,6 +344,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_19_0
 displayName: Quarkus Updates Aggregate 3.19.0
 description: Quarkus update recipes to upgrade your application to 3.19.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.19.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_18_0
   - io.quarkus.updates.core.quarkus319.MoveAccessTokenAnnotationToNewPackage
@@ -270,6 +360,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_20_1
 displayName: Quarkus Updates Aggregate 3.20.1
 description: Quarkus update recipes to upgrade your application to 3.20.1.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.20.1)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_19_0
   - io.quarkus.updates.camel.camel410_4.CamelQuarkusMigrationRecipe
@@ -279,6 +374,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_21_0
 displayName: Quarkus Updates Aggregate 3.21.0
 description: Quarkus update recipes to upgrade your application to 3.21.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.21.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_20_1
   - io.quarkus.updates.core.quarkus321.TlsRegistrySplitPackagesFix
@@ -288,6 +388,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_22_0
 displayName: Quarkus Updates Aggregate 3.22.0
 description: Quarkus update recipes to upgrade your application to 3.22.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.22.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_21_0
   - io.quarkus.updates.camel.camel411.CamelQuarkusMigrationRecipe
@@ -297,6 +402,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_23_0
 displayName: Quarkus Updates Aggregate 3.23.0
 description: Quarkus update recipes to upgrade your application to 3.23.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.23.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_22_0
   - io.quarkus.updates.core.quarkus323.HibernateORMSchemaManagementProperties
@@ -306,6 +416,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_24_0
 displayName: Quarkus Updates Aggregate 3.24.0
 description: Quarkus update recipes to upgrade your application to 3.24.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.24.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_23_0
   - io.quarkus.updates.core.quarkus324.ReplaceOldJpaModelgenAnnotationProcessor
@@ -323,6 +438,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_25_0
 displayName: Quarkus Updates Aggregate 3.25.0
 description: Quarkus update recipes to upgrade your application to 3.25.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.25.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_24_0
   - io.quarkus.updates.camel.camel413.CamelQuarkusMigrationRecipe
@@ -332,6 +452,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_26_0
 displayName: Quarkus Updates Aggregate 3.26.0
 description: Quarkus update recipes to upgrade your application to 3.26.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.26.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_25_0
   - io.quarkus.updates.core.quarkus326.EnableEnabledConfigChanges
@@ -342,6 +467,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_29_0
 displayName: Quarkus Updates Aggregate 3.29.0
 description: Quarkus update recipes to upgrade your application to 3.29.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.29.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_26_0
   - io.quarkus.updates.camel.camel415.CamelQuarkusMigrationRecipe
@@ -351,6 +481,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_30_0
 displayName: Quarkus Updates Aggregate 3.30.0
 description: Quarkus update recipes to upgrade your application to 3.30.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.30.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_29_0
   - io.quarkus.updates.core.quarkus330.RenameEnableMetrics
@@ -361,6 +496,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_31_0
 displayName: Quarkus Updates Aggregate 3.31.0
 description: Quarkus update recipes to upgrade your application to 3.31.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.31.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_30_0
   - io.quarkus.updates.core.quarkus331.CoreUpdate331
@@ -375,6 +515,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.quarkus.MigrateToQuarkus_v3_32_0
 displayName: Quarkus Updates Aggregate 3.32.0
 description: Quarkus update recipes to upgrade your application to 3.32.0.
+preconditions:
+  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+      groupIdPattern: io.quarkus.platform
+      artifactIdPattern: quarkus-bom
+      version: (,3.32.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_31_0
   - io.quarkus.updates.camel.camel418.CamelQuarkusMigrationRecipe

--- a/src/main/resources/META-INF/rewrite/quarkus-consolidated.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-consolidated.yml
@@ -22,8 +22,8 @@ displayName: Quarkus Updates Aggregate 3.0.0
 description: Quarkus update recipes to upgrade your application to 3.0.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.0.0)
 recipeList:
   - io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe
@@ -85,8 +85,8 @@ displayName: Quarkus Updates Aggregate 3.1.0
 description: Quarkus update recipes to upgrade your application to 3.1.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.1.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0
@@ -99,8 +99,8 @@ displayName: Quarkus Updates Aggregate 3.2.0
 description: Quarkus update recipes to upgrade your application to 3.2.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.2.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_1_0
@@ -115,8 +115,8 @@ displayName: Quarkus Updates Aggregate 3.3.0
 description: Quarkus update recipes to upgrade your application to 3.3.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.3.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_2_0
@@ -131,8 +131,8 @@ displayName: Quarkus Updates Aggregate 3.5.0
 description: Quarkus update recipes to upgrade your application to 3.5.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.5.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_3_0
@@ -146,8 +146,8 @@ displayName: Quarkus Updates Aggregate 3.6.0
 description: Quarkus update recipes to upgrade your application to 3.6.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.6.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_5_0
@@ -160,8 +160,8 @@ displayName: Quarkus Updates Aggregate 3.7.0
 description: Quarkus update recipes to upgrade your application to 3.7.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.7.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_6_0
@@ -187,8 +187,8 @@ displayName: Quarkus Updates Aggregate 3.8.0
 description: Quarkus update recipes to upgrade your application to 3.8.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.8.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_7_0
@@ -203,8 +203,8 @@ displayName: Quarkus Updates Aggregate 3.8.3
 description: Quarkus update recipes to upgrade your application to 3.8.3.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.8.3)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_8_0
@@ -217,8 +217,8 @@ displayName: Quarkus Updates Aggregate 3.9.0
 description: Quarkus update recipes to upgrade your application to 3.9.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.9.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_8_3
@@ -235,8 +235,8 @@ displayName: Quarkus Updates Aggregate 3.10.0
 description: Quarkus update recipes to upgrade your application to 3.10.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.10.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_9_0
@@ -260,8 +260,8 @@ displayName: Quarkus Updates Aggregate 3.11.0
 description: Quarkus update recipes to upgrade your application to 3.11.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.11.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_10_0
@@ -274,8 +274,8 @@ displayName: Quarkus Updates Aggregate 3.12.0
 description: Quarkus update recipes to upgrade your application to 3.12.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.12.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_11_0
@@ -288,8 +288,8 @@ displayName: Quarkus Updates Aggregate 3.13.0
 description: Quarkus update recipes to upgrade your application to 3.13.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.13.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_12_0
@@ -303,8 +303,8 @@ displayName: Quarkus Updates Aggregate 3.15.0
 description: Quarkus update recipes to upgrade your application to 3.15.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.15.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_13_0
@@ -317,8 +317,8 @@ displayName: Quarkus Updates Aggregate 3.17.0
 description: Quarkus update recipes to upgrade your application to 3.17.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.17.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_15_0
@@ -331,8 +331,8 @@ displayName: Quarkus Updates Aggregate 3.18.0
 description: Quarkus update recipes to upgrade your application to 3.18.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.18.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_17_0
@@ -346,8 +346,8 @@ displayName: Quarkus Updates Aggregate 3.19.0
 description: Quarkus update recipes to upgrade your application to 3.19.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.19.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_18_0
@@ -362,8 +362,8 @@ displayName: Quarkus Updates Aggregate 3.20.1
 description: Quarkus update recipes to upgrade your application to 3.20.1.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.20.1)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_19_0
@@ -376,8 +376,8 @@ displayName: Quarkus Updates Aggregate 3.21.0
 description: Quarkus update recipes to upgrade your application to 3.21.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.21.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_20_1
@@ -390,8 +390,8 @@ displayName: Quarkus Updates Aggregate 3.22.0
 description: Quarkus update recipes to upgrade your application to 3.22.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.22.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_21_0
@@ -404,8 +404,8 @@ displayName: Quarkus Updates Aggregate 3.23.0
 description: Quarkus update recipes to upgrade your application to 3.23.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.23.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_22_0
@@ -418,8 +418,8 @@ displayName: Quarkus Updates Aggregate 3.24.0
 description: Quarkus update recipes to upgrade your application to 3.24.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.24.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_23_0
@@ -440,8 +440,8 @@ displayName: Quarkus Updates Aggregate 3.25.0
 description: Quarkus update recipes to upgrade your application to 3.25.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.25.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_24_0
@@ -454,8 +454,8 @@ displayName: Quarkus Updates Aggregate 3.26.0
 description: Quarkus update recipes to upgrade your application to 3.26.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.26.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_25_0
@@ -469,8 +469,8 @@ displayName: Quarkus Updates Aggregate 3.29.0
 description: Quarkus update recipes to upgrade your application to 3.29.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.29.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_26_0
@@ -483,8 +483,8 @@ displayName: Quarkus Updates Aggregate 3.30.0
 description: Quarkus update recipes to upgrade your application to 3.30.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.30.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_29_0
@@ -498,8 +498,8 @@ displayName: Quarkus Updates Aggregate 3.31.0
 description: Quarkus update recipes to upgrade your application to 3.31.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.31.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_30_0
@@ -517,8 +517,8 @@ displayName: Quarkus Updates Aggregate 3.32.0
 description: Quarkus update recipes to upgrade your application to 3.32.0.
 preconditions:
   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-      groupIdPattern: io.quarkus.platform
-      artifactIdPattern: quarkus-bom
+      groupIdPattern: io.quarkus
+      artifactIdPattern: quarkus-core
       version: (,3.32.0)
 recipeList:
   - org.openrewrite.quarkus.MigrateToQuarkus_v3_31_0

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdates.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdates.java
@@ -113,8 +113,8 @@ public class AggregateQuarkusUpdates {
             description: Quarkus update recipes to upgrade your application to %s.
             preconditions:
               - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-                  groupIdPattern: io.quarkus.platform
-                  artifactIdPattern: quarkus-bom
+                  groupIdPattern: io.quarkus
+                  artifactIdPattern: quarkus-core
                   version: (,%s)
             recipeList:%s
               - %s

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdates.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdates.java
@@ -111,11 +111,17 @@ public class AggregateQuarkusUpdates {
             name: %s
             displayName: Quarkus Updates Aggregate %s
             description: Quarkus update recipes to upgrade your application to %s.
+            preconditions:
+              - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+                  groupIdPattern: io.quarkus.platform
+                  artifactIdPattern: quarkus-bom
+                  version: (,%s)
             recipeList:%s
               - %s
 
             """.formatted(
             recipeNameFor(version),
+            version,
             version,
             version,
             priorVersion != null ? "\n  - " + recipeNameFor(priorVersion) : "",

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdatesTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdatesTest.java
@@ -93,6 +93,11 @@ class AggregateQuarkusUpdatesTest {
                 name: org.openrewrite.quarkus.MigrateToQuarkus_v1_2_3
                 displayName: Quarkus Updates Aggregate 1.2.3
                 description: Quarkus update recipes to upgrade your application to 1.2.3.
+                preconditions:
+                  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+                      groupIdPattern: io.quarkus.platform
+                      artifactIdPattern: quarkus-bom
+                      version: (,1.2.3)
                 recipeList:
                   - org.openrewrite.quarkus.MigrateToQuarkus_v1_2_0
                   - org.test.r1
@@ -113,6 +118,11 @@ class AggregateQuarkusUpdatesTest {
                 name: org.openrewrite.quarkus.MigrateToQuarkus_v1_2_3
                 displayName: Quarkus Updates Aggregate 1.2.3
                 description: Quarkus update recipes to upgrade your application to 1.2.3.
+                preconditions:
+                  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+                      groupIdPattern: io.quarkus.platform
+                      artifactIdPattern: quarkus-bom
+                      version: (,1.2.3)
                 recipeList:
                   - org.test.r1
                   - org.test.r2

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdatesTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/AggregateQuarkusUpdatesTest.java
@@ -95,8 +95,8 @@ class AggregateQuarkusUpdatesTest {
                 description: Quarkus update recipes to upgrade your application to 1.2.3.
                 preconditions:
                   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-                      groupIdPattern: io.quarkus.platform
-                      artifactIdPattern: quarkus-bom
+                      groupIdPattern: io.quarkus
+                      artifactIdPattern: quarkus-core
                       version: (,1.2.3)
                 recipeList:
                   - org.openrewrite.quarkus.MigrateToQuarkus_v1_2_0
@@ -120,8 +120,8 @@ class AggregateQuarkusUpdatesTest {
                 description: Quarkus update recipes to upgrade your application to 1.2.3.
                 preconditions:
                   - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-                      groupIdPattern: io.quarkus.platform
-                      artifactIdPattern: quarkus-bom
+                      groupIdPattern: io.quarkus
+                      artifactIdPattern: quarkus-core
                       version: (,1.2.3)
                 recipeList:
                   - org.test.r1

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
@@ -17,10 +17,8 @@ package org.openrewrite.recipe.quarkus.internal;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.java.dependencies.search.ModuleHasDependency;
 import org.openrewrite.test.RewriteTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -33,22 +31,6 @@ class QuarkusPreconditionTest implements RewriteTest {
 
     private static final String GROUP = "jakarta.data";
     private static final String ARTIFACT = "jakarta.data-api";
-
-    private static final String POM = """
-        <project>
-            <modelVersion>4.0.0</modelVersion>
-            <groupId>com.example</groupId>
-            <artifactId>test</artifactId>
-            <version>1.0</version>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.data</groupId>
-                    <artifactId>jakarta.data-api</artifactId>
-                    <version>1.0.1</version>
-                </dependency>
-            </dependencies>
-        </project>
-        """;
 
     private static final String POM_WITH_PROPERTY = """
         <project>
@@ -112,38 +94,6 @@ class QuarkusPreconditionTest implements RewriteTest {
 
     private static String migrationRecipeName(String targetVersion) {
         return "test.MigrateToVersion_" + targetVersion.replace(".", "_");
-    }
-
-    @Nested
-    class DirectModuleHasDependency {
-        @Test
-        void marksWhenVersionBelowRange() {
-            rewriteRun(
-                spec -> spec.recipe(new ModuleHasDependency(GROUP, ARTIFACT, null, "(,1.1.0)", null)),
-                mavenProject("project",
-                    pomXml(POM,
-                        spec -> spec.after(actual ->
-                            assertThat(actual).startsWith("<!--~~(Module has dependency").actual())))
-            );
-        }
-
-        @Test
-        void doesNotMarkWhenVersionAtRange() {
-            rewriteRun(
-                spec -> spec.recipe(new ModuleHasDependency(GROUP, ARTIFACT, null, "(,1.0.1)", null)),
-                mavenProject("project",
-                    pomXml(POM))
-            );
-        }
-
-        @Test
-        void doesNotMarkWhenVersionAboveRange() {
-            rewriteRun(
-                spec -> spec.recipe(new ModuleHasDependency(GROUP, ARTIFACT, null, "(,1.0.0)", null)),
-                mavenProject("project",
-                    pomXml(POM))
-            );
-        }
     }
 
     @Nested

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
@@ -16,12 +16,10 @@
 package org.openrewrite.recipe.quarkus.internal;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.RecipeRun;
-import org.openrewrite.SourceFile;
+import org.openrewrite.*;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.YamlResourceLoader;
+import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.maven.MavenParser;
 
 import java.io.InputStream;
@@ -37,22 +35,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Verifies that the generated Quarkus aggregation recipes from
  * {@code quarkus-consolidated.yml} do not run on projects whose
- * {@code io.quarkus.platform:quarkus-bom} version is at or above
- * the recipe's target version.
+ * {@code io.quarkus:quarkus-core} version is at or above the recipe's target version.
  */
 class QuarkusPreconditionTest {
 
-    /**
-     * Build an Environment that includes both the consolidated recipes from
-     * {@code META-INF/rewrite/} and the individual quarkus update recipes
-     * from the {@code quarkus-updates/} path inside the quarkus-update-recipes JAR.
-     */
     private static Recipe loadConsolidatedRecipe(String recipeName) {
         try {
             Environment.Builder builder = Environment.builder().scanRuntimeClasspath();
-
-            // The quarkus-update-recipes JAR stores its YAML recipes under quarkus-updates/
-            // instead of META-INF/rewrite/, so they're not picked up by scanRuntimeClasspath().
             URL marker = QuarkusPreconditionTest.class.getClassLoader()
                     .getResource("quarkus-updates/core/3.0.alpha1.yaml");
             if (marker != null) {
@@ -71,47 +60,81 @@ class QuarkusPreconditionTest {
                             });
                 }
             }
-
             return builder.build().activateRecipes(recipeName);
         } catch (Exception e) {
             throw new RuntimeException("Failed to load consolidated recipe: " + recipeName, e);
         }
     }
 
-    @Test
-    void doesNotRunWhenQuarkusVersionIsAtTarget() {
-        Recipe recipe = loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_17_0");
+    private static String pomWithQuarkusBom(String bomVersion) {
+        return """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0</version>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.quarkus.platform</groupId>
+                                <artifactId>quarkus-bom</artifactId>
+                                <version>%s</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-core</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.validation</groupId>
+                            <artifactId>validation-api</artifactId>
+                            <version>2.0.1.Final</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """.formatted(bomVersion);
+    }
 
-        // A project on quarkus-bom 3.17.0 should NOT be modified by MigrateToQuarkus_v3_17_0,
-        // because the precondition version: (,3.17.0) excludes 3.17.0 itself
+    private static RecipeRun runRecipe(Recipe recipe, String pom) {
+        JavaProject javaProject = new JavaProject(Tree.randomId(), "test", null);
         List<SourceFile> sources = MavenParser.builder().build().parse(
-                new InMemoryExecutionContext(Throwable::printStackTrace),
-                """
-                        <project>
-                            <modelVersion>4.0.0</modelVersion>
-                            <groupId>com.example</groupId>
-                            <artifactId>test</artifactId>
-                            <version>1.0</version>
-                            <dependencyManagement>
-                                <dependencies>
-                                    <dependency>
-                                        <groupId>io.quarkus.platform</groupId>
-                                        <artifactId>quarkus-bom</artifactId>
-                                        <version>3.17.0</version>
-                                        <type>pom</type>
-                                        <scope>import</scope>
-                                    </dependency>
-                                </dependencies>
-                            </dependencyManagement>
-                        </project>
-                        """).toList();
-
-        RecipeRun result = recipe.run(
+                        new InMemoryExecutionContext(Throwable::printStackTrace), pom)
+                .map(s -> (SourceFile) s.withMarkers(s.getMarkers().add(javaProject)))
+                .toList();
+        return recipe.run(
                 new org.openrewrite.internal.InMemoryLargeSourceSet(sources),
                 new InMemoryExecutionContext(Throwable::printStackTrace));
+    }
+
+    @Test
+    void doesNotRunWhenQuarkusVersionIsAtTarget() {
+        Recipe recipe = loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0");
+
+        // A project on quarkus-bom 3.0.0.Final should NOT be modified,
+        // because the precondition version: (,3.0.0) excludes 3.0.0 itself.
+        // quarkus-core resolves to 3.0.0.Final via the BOM.
+        RecipeRun result = runRecipe(recipe, pomWithQuarkusBom("3.0.0.Final"));
 
         assertThat(result.getChangeset().getAllResults())
-                .as("MigrateToQuarkus_v3_17_0 should not modify a project already on quarkus-bom 3.17.0")
+                .as("MigrateToQuarkus_v3_0_0 should not modify a project already on quarkus-bom 3.0.0.Final")
                 .isEmpty();
+    }
+
+    @Test
+    void runsWhenQuarkusVersionIsBelowTarget() {
+        Recipe recipe = loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0");
+
+        // A project on quarkus-bom 2.16.12.Final SHOULD be modified,
+        // because the precondition version: (,3.0.0) includes 2.x versions.
+        // The javax.validation:validation-api dependency should be migrated to jakarta.
+        RecipeRun result = runRecipe(recipe, pomWithQuarkusBom("2.16.12.Final"));
+
+        assertThat(result.getChangeset().getAllResults())
+                .as("MigrateToQuarkus_v3_0_0 should modify a project on quarkus-bom 2.16.12.Final")
+                .isNotEmpty();
     }
 }

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
@@ -15,120 +15,66 @@
  */
 package org.openrewrite.recipe.quarkus.internal;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.mavenProject;
-import static org.openrewrite.maven.Assertions.pomXml;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies that a {@code ModuleHasDependency} precondition with a version range
- * prevents recipes from running when the module's dependency version is at or above
- * the target. This is the same pattern used by the generated Quarkus aggregation recipes.
+ * Verifies that every recipe in {@code quarkus-consolidated.yml} has a
+ * {@code ModuleHasDependency} precondition checking for
+ * {@code io.quarkus.platform:quarkus-bom} with an exclusive upper-bound
+ * version range, so migrations only run from the user's current version onwards.
  */
-class QuarkusPreconditionTest implements RewriteTest {
+class QuarkusPreconditionTest {
 
-    private static final String GROUP = "jakarta.data";
-    private static final String ARTIFACT = "jakarta.data-api";
+    private static final Path CONSOLIDATED_YML =
+            Path.of("src/main/resources/META-INF/rewrite/quarkus-consolidated.yml");
 
-    private static final String POM_WITH_PROPERTY = """
-        <project>
-            <modelVersion>4.0.0</modelVersion>
-            <groupId>com.example</groupId>
-            <artifactId>test</artifactId>
-            <version>1.0</version>
-            <properties>
-                <migrated>false</migrated>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.data</groupId>
-                    <artifactId>jakarta.data-api</artifactId>
-                    <version>1.0.1</version>
-                </dependency>
-            </dependencies>
-        </project>
-        """;
+    @Test
+    void allRecipesHaveModuleHasDependencyPrecondition() throws IOException {
+        assertThat(CONSOLIDATED_YML).exists();
+        String content = Files.readString(CONSOLIDATED_YML);
 
-    private static final String POM_WITH_PROPERTY_MIGRATED = """
-        <project>
-            <modelVersion>4.0.0</modelVersion>
-            <groupId>com.example</groupId>
-            <artifactId>test</artifactId>
-            <version>1.0</version>
-            <properties>
-                <migrated>true</migrated>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.data</groupId>
-                    <artifactId>jakarta.data-api</artifactId>
-                    <version>1.0.1</version>
-                </dependency>
-            </dependencies>
-        </project>
-        """;
+        // Find all recipe blocks: each starts with "name: org.openrewrite.quarkus.MigrateToQuarkus_vX_Y_Z"
+        Pattern recipePattern = Pattern.compile(
+                "name: (org\\.openrewrite\\.quarkus\\.MigrateToQuarkus_v(\\d+_\\d+_\\d+))");
+        Matcher matcher = recipePattern.matcher(content);
 
-    private static String migrationRecipeYaml(String targetVersion) {
-        return """
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.MigrateToVersion_%s
-            displayName: Test migrate to %s
-            description: Test.
-            preconditions:
-              - org.openrewrite.java.dependencies.search.ModuleHasDependency:
-                  groupIdPattern: %s
-                  artifactIdPattern: %s
-                  version: (,%s)
-            recipeList:
-              - org.openrewrite.maven.ChangePropertyValue:
-                  key: migrated
-                  newValue: "true"
-            """.formatted(
-            targetVersion.replace(".", "_"),
-            targetVersion,
-            GROUP, ARTIFACT,
-            targetVersion);
-    }
+        int recipeCount = 0;
+        while (matcher.find()) {
+            String recipeName = matcher.group(1);
+            String expectedVersion = matcher.group(2).replace("_", ".");
 
-    private static String migrationRecipeName(String targetVersion) {
-        return "test.MigrateToVersion_" + targetVersion.replace(".", "_");
-    }
+            // Find the block for this recipe (from this name: to the next --- or end of file)
+            int blockStart = matcher.start();
+            int blockEnd = content.indexOf("\n---", blockStart);
+            if (blockEnd == -1) {
+                blockEnd = content.length();
+            }
+            String block = content.substring(blockStart, blockEnd);
 
-    @Nested
-    class YamlPrecondition {
-        @Test
-        void runsWhenVersionBelowTarget() {
-            // 1.0.1 IS less than 1.1.0, so recipe should run and change the property
-            String version = "1.1.0";
-            rewriteRun(
-                spec -> spec.recipeFromYaml(migrationRecipeYaml(version), migrationRecipeName(version)),
-                mavenProject("project",
-                    pomXml(POM_WITH_PROPERTY, POM_WITH_PROPERTY_MIGRATED))
-            );
+            assertThat(block)
+                    .as("Recipe %s should have ModuleHasDependency precondition", recipeName)
+                    .contains("org.openrewrite.java.dependencies.search.ModuleHasDependency:");
+            assertThat(block)
+                    .as("Recipe %s should check io.quarkus.platform group", recipeName)
+                    .contains("groupIdPattern: io.quarkus.platform");
+            assertThat(block)
+                    .as("Recipe %s should check quarkus-bom artifact", recipeName)
+                    .contains("artifactIdPattern: quarkus-bom");
+            assertThat(block)
+                    .as("Recipe %s should have version range (,%s)", recipeName, expectedVersion)
+                    .contains("version: (," + expectedVersion + ")");
+
+            recipeCount++;
         }
 
-        @Test
-        void doesNotRunWhenVersionAtTarget() {
-            // 1.0.1 is NOT less than 1.0.1, so recipe should not run
-            String version = "1.0.1";
-            rewriteRun(
-                spec -> spec.recipeFromYaml(migrationRecipeYaml(version), migrationRecipeName(version)),
-                mavenProject("project",
-                    pomXml(POM_WITH_PROPERTY))
-            );
-        }
-
-        @Test
-        void doesNotRunWhenVersionAboveTarget() {
-            // 1.0.1 is NOT less than 1.0.0, so recipe should not run
-            String version = "1.0.0";
-            rewriteRun(
-                spec -> spec.recipeFromYaml(migrationRecipeYaml(version), migrationRecipeName(version)),
-                mavenProject("project",
-                    pomXml(POM_WITH_PROPERTY))
-            );
-        }
+        assertThat(recipeCount).as("Should have found multiple recipes in consolidated YAML").isGreaterThan(1);
     }
 }

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.recipe.quarkus.internal;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.dependencies.search.ModuleHasDependency;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+/**
+ * Verifies that a {@code ModuleHasDependency} precondition with a version range
+ * prevents recipes from running when the module's dependency version is at or above
+ * the target. This is the same pattern used by the generated Quarkus aggregation recipes.
+ */
+class QuarkusPreconditionTest implements RewriteTest {
+
+    private static final String GROUP = "jakarta.data";
+    private static final String ARTIFACT = "jakarta.data-api";
+
+    private static final String POM = """
+        <project>
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>com.example</groupId>
+            <artifactId>test</artifactId>
+            <version>1.0</version>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.data</groupId>
+                    <artifactId>jakarta.data-api</artifactId>
+                    <version>1.0.1</version>
+                </dependency>
+            </dependencies>
+        </project>
+        """;
+
+    private static final String POM_WITH_PROPERTY = """
+        <project>
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>com.example</groupId>
+            <artifactId>test</artifactId>
+            <version>1.0</version>
+            <properties>
+                <migrated>false</migrated>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.data</groupId>
+                    <artifactId>jakarta.data-api</artifactId>
+                    <version>1.0.1</version>
+                </dependency>
+            </dependencies>
+        </project>
+        """;
+
+    private static final String POM_WITH_PROPERTY_MIGRATED = """
+        <project>
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>com.example</groupId>
+            <artifactId>test</artifactId>
+            <version>1.0</version>
+            <properties>
+                <migrated>true</migrated>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.data</groupId>
+                    <artifactId>jakarta.data-api</artifactId>
+                    <version>1.0.1</version>
+                </dependency>
+            </dependencies>
+        </project>
+        """;
+
+    private static String migrationRecipeYaml(String targetVersion) {
+        return """
+            type: specs.openrewrite.org/v1beta/recipe
+            name: test.MigrateToVersion_%s
+            displayName: Test migrate to %s
+            description: Test.
+            preconditions:
+              - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+                  groupIdPattern: %s
+                  artifactIdPattern: %s
+                  version: (,%s)
+            recipeList:
+              - org.openrewrite.maven.ChangePropertyValue:
+                  key: migrated
+                  newValue: "true"
+            """.formatted(
+            targetVersion.replace(".", "_"),
+            targetVersion,
+            GROUP, ARTIFACT,
+            targetVersion);
+    }
+
+    private static String migrationRecipeName(String targetVersion) {
+        return "test.MigrateToVersion_" + targetVersion.replace(".", "_");
+    }
+
+    @Nested
+    class DirectModuleHasDependency {
+        @Test
+        void marksWhenVersionBelowRange() {
+            rewriteRun(
+                spec -> spec.recipe(new ModuleHasDependency(GROUP, ARTIFACT, null, "(,1.1.0)", null)),
+                mavenProject("project",
+                    pomXml(POM,
+                        spec -> spec.after(actual ->
+                            assertThat(actual).startsWith("<!--~~(Module has dependency").actual())))
+            );
+        }
+
+        @Test
+        void doesNotMarkWhenVersionAtRange() {
+            rewriteRun(
+                spec -> spec.recipe(new ModuleHasDependency(GROUP, ARTIFACT, null, "(,1.0.1)", null)),
+                mavenProject("project",
+                    pomXml(POM))
+            );
+        }
+
+        @Test
+        void doesNotMarkWhenVersionAboveRange() {
+            rewriteRun(
+                spec -> spec.recipe(new ModuleHasDependency(GROUP, ARTIFACT, null, "(,1.0.0)", null)),
+                mavenProject("project",
+                    pomXml(POM))
+            );
+        }
+    }
+
+    @Nested
+    class YamlPrecondition {
+        @Test
+        void runsWhenVersionBelowTarget() {
+            // 1.0.1 IS less than 1.1.0, so recipe should run and change the property
+            String version = "1.1.0";
+            rewriteRun(
+                spec -> spec.recipeFromYaml(migrationRecipeYaml(version), migrationRecipeName(version)),
+                mavenProject("project",
+                    pomXml(POM_WITH_PROPERTY, POM_WITH_PROPERTY_MIGRATED))
+            );
+        }
+
+        @Test
+        void doesNotRunWhenVersionAtTarget() {
+            // 1.0.1 is NOT less than 1.0.1, so recipe should not run
+            String version = "1.0.1";
+            rewriteRun(
+                spec -> spec.recipeFromYaml(migrationRecipeYaml(version), migrationRecipeName(version)),
+                mavenProject("project",
+                    pomXml(POM_WITH_PROPERTY))
+            );
+        }
+
+        @Test
+        void doesNotRunWhenVersionAboveTarget() {
+            // 1.0.1 is NOT less than 1.0.0, so recipe should not run
+            String version = "1.0.0";
+            rewriteRun(
+                spec -> spec.recipeFromYaml(migrationRecipeYaml(version), migrationRecipeName(version)),
+                mavenProject("project",
+                    pomXml(POM_WITH_PROPERTY))
+            );
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
@@ -16,48 +16,53 @@
 package org.openrewrite.recipe.quarkus.internal;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.*;
+import org.openrewrite.Recipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.YamlResourceLoader;
-import org.openrewrite.java.marker.JavaProject;
-import org.openrewrite.maven.MavenParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
 
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
-import java.util.List;
 import java.util.Properties;
 import java.util.jar.JarFile;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 /**
  * Verifies that the generated Quarkus aggregation recipes from
  * {@code quarkus-consolidated.yml} do not run on projects whose
  * {@code io.quarkus:quarkus-core} version is at or above the recipe's target version.
  */
-class QuarkusPreconditionTest {
+class QuarkusPreconditionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_1_0"));
+    }
 
     private static Recipe loadConsolidatedRecipe(String recipeName) {
         try {
             Environment.Builder builder = Environment.builder().scanRuntimeClasspath();
-            URL marker = QuarkusPreconditionTest.class.getClassLoader()
-                    .getResource("quarkus-updates/core/3.0.alpha1.yaml");
+            URL marker = QuarkusPreconditionTest.class.getClassLoader().getResource("quarkus-updates/core/3.0.alpha1.yaml");
             if (marker != null) {
                 String jarPath = marker.getPath().substring("file:".length(), marker.getPath().indexOf("!"));
                 try (JarFile jar = new JarFile(jarPath)) {
                     jar.stream()
-                            .filter(e -> e.getName().startsWith("quarkus-updates/") && e.getName().endsWith(".yaml"))
-                            .forEach(entry -> {
-                                try (InputStream is = jar.getInputStream(entry)) {
-                                    builder.load(new YamlResourceLoader(
-                                            is, URI.create(entry.getName()), new Properties(),
-                                            (ClassLoader) null, emptyList()));
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
+                      .filter(e -> e.getName().startsWith("quarkus-updates/") && e.getName().endsWith(".yaml"))
+                      .forEach(entry -> {
+                          try (InputStream is = jar.getInputStream(entry)) {
+                              builder.load(new YamlResourceLoader(
+                                is, URI.create(entry.getName()), new Properties(),
+                                (ClassLoader) null, emptyList()));
+                          } catch (Exception e) {
+                              throw new RuntimeException(e);
+                          }
+                      });
                 }
             }
             return builder.build().activateRecipes(recipeName);
@@ -67,74 +72,65 @@ class QuarkusPreconditionTest {
     }
 
     private static String pomWithQuarkusBom(String bomVersion) {
+        //language=xml
         return """
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>test</artifactId>
-                    <version>1.0</version>
-                    <dependencyManagement>
-                        <dependencies>
-                            <dependency>
-                                <groupId>io.quarkus.platform</groupId>
-                                <artifactId>quarkus-bom</artifactId>
-                                <version>%s</version>
-                                <type>pom</type>
-                                <scope>import</scope>
-                            </dependency>
-                        </dependencies>
-                    </dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.quarkus</groupId>
-                            <artifactId>quarkus-core</artifactId>
-                        </dependency>
-                        <dependency>
-                            <groupId>javax.validation</groupId>
-                            <artifactId>validation-api</artifactId>
-                            <version>2.0.1.Final</version>
-                        </dependency>
-                    </dependencies>
-                </project>
-                """.formatted(bomVersion);
-    }
-
-    private static RecipeRun runRecipe(Recipe recipe, String pom) {
-        JavaProject javaProject = new JavaProject(Tree.randomId(), "test", null);
-        List<SourceFile> sources = MavenParser.builder().build().parse(
-                        new InMemoryExecutionContext(Throwable::printStackTrace), pom)
-                .map(s -> (SourceFile) s.withMarkers(s.getMarkers().add(javaProject)))
-                .toList();
-        return recipe.run(
-                new org.openrewrite.internal.InMemoryLargeSourceSet(sources),
-                new InMemoryExecutionContext(Throwable::printStackTrace));
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>test</artifactId>
+              <version>1.0</version>
+              <dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>io.quarkus.platform</groupId>
+                          <artifactId>quarkus-bom</artifactId>
+                          <version>%s</version>
+                          <type>pom</type>
+                          <scope>import</scope>
+                      </dependency>
+                  </dependencies>
+              </dependencyManagement>
+              <dependencies>
+                  <dependency>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-core</artifactId>
+                  </dependency>
+                  <dependency>
+                      <groupId>javax.validation</groupId>
+                      <artifactId>validation-api</artifactId>
+                      <version>2.0.1.Final</version>
+                  </dependency>
+              </dependencies>
+          </project>
+          """.formatted(bomVersion);
     }
 
     @Test
     void doesNotRunWhenQuarkusVersionIsAtTarget() {
-        Recipe recipe = loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0");
-
-        // A project on quarkus-bom 3.0.0.Final should NOT be modified,
-        // because the precondition version: (,3.0.0) excludes 3.0.0 itself.
-        // quarkus-core resolves to 3.0.0.Final via the BOM.
-        RecipeRun result = runRecipe(recipe, pomWithQuarkusBom("3.0.0.Final"));
-
-        assertThat(result.getChangeset().getAllResults())
-                .as("MigrateToQuarkus_v3_0_0 should not modify a project already on quarkus-bom 3.0.0.Final")
-                .isEmpty();
+        // A project on quarkus-bom 3.1.0.Final should NOT be modified,
+        // because the precondition version: (,3.1.0) excludes 3.1.0 itself.
+        // quarkus-core resolves to 3.1.0.Final via the BOM.
+        rewriteRun(
+          mavenProject(
+            "project",
+            pomXml(pomWithQuarkusBom("3.1.0.Final"))
+          )
+        );
     }
 
     @Test
     void runsWhenQuarkusVersionIsBelowTarget() {
-        Recipe recipe = loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0");
-
-        // A project on quarkus-bom 2.16.12.Final SHOULD be modified,
-        // because the precondition version: (,3.0.0) includes 2.x versions.
-        // The javax.validation:validation-api dependency should be migrated to jakarta.
-        RecipeRun result = runRecipe(recipe, pomWithQuarkusBom("2.16.12.Final"));
-
-        assertThat(result.getChangeset().getAllResults())
-                .as("MigrateToQuarkus_v3_0_0 should modify a project on quarkus-bom 2.16.12.Final")
-                .isNotEmpty();
+        rewriteRun(
+          mavenProject(
+            "project",
+            pomXml(
+              pomWithQuarkusBom("2.16.12.Final"),
+              after -> after.after(pom -> assertThat(pom)
+                .doesNotContain("javax")
+                .contains("jakarta")
+                .actual())
+            )
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
+++ b/src/test/java/org/openrewrite/recipe/quarkus/internal/QuarkusPreconditionTest.java
@@ -16,65 +16,102 @@
 package org.openrewrite.recipe.quarkus.internal;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.RecipeRun;
+import org.openrewrite.SourceFile;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.YamlResourceLoader;
+import org.openrewrite.maven.MavenParser;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+import java.util.jar.JarFile;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies that every recipe in {@code quarkus-consolidated.yml} has a
- * {@code ModuleHasDependency} precondition checking for
- * {@code io.quarkus.platform:quarkus-bom} with an exclusive upper-bound
- * version range, so migrations only run from the user's current version onwards.
+ * Verifies that the generated Quarkus aggregation recipes from
+ * {@code quarkus-consolidated.yml} do not run on projects whose
+ * {@code io.quarkus.platform:quarkus-bom} version is at or above
+ * the recipe's target version.
  */
 class QuarkusPreconditionTest {
 
-    private static final Path CONSOLIDATED_YML =
-            Path.of("src/main/resources/META-INF/rewrite/quarkus-consolidated.yml");
+    /**
+     * Build an Environment that includes both the consolidated recipes from
+     * {@code META-INF/rewrite/} and the individual quarkus update recipes
+     * from the {@code quarkus-updates/} path inside the quarkus-update-recipes JAR.
+     */
+    private static Recipe loadConsolidatedRecipe(String recipeName) {
+        try {
+            Environment.Builder builder = Environment.builder().scanRuntimeClasspath();
+
+            // The quarkus-update-recipes JAR stores its YAML recipes under quarkus-updates/
+            // instead of META-INF/rewrite/, so they're not picked up by scanRuntimeClasspath().
+            URL marker = QuarkusPreconditionTest.class.getClassLoader()
+                    .getResource("quarkus-updates/core/3.0.alpha1.yaml");
+            if (marker != null) {
+                String jarPath = marker.getPath().substring("file:".length(), marker.getPath().indexOf("!"));
+                try (JarFile jar = new JarFile(jarPath)) {
+                    jar.stream()
+                            .filter(e -> e.getName().startsWith("quarkus-updates/") && e.getName().endsWith(".yaml"))
+                            .forEach(entry -> {
+                                try (InputStream is = jar.getInputStream(entry)) {
+                                    builder.load(new YamlResourceLoader(
+                                            is, URI.create(entry.getName()), new Properties(),
+                                            (ClassLoader) null, emptyList()));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+                }
+            }
+
+            return builder.build().activateRecipes(recipeName);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load consolidated recipe: " + recipeName, e);
+        }
+    }
 
     @Test
-    void allRecipesHaveModuleHasDependencyPrecondition() throws IOException {
-        assertThat(CONSOLIDATED_YML).exists();
-        String content = Files.readString(CONSOLIDATED_YML);
+    void doesNotRunWhenQuarkusVersionIsAtTarget() {
+        Recipe recipe = loadConsolidatedRecipe("org.openrewrite.quarkus.MigrateToQuarkus_v3_17_0");
 
-        // Find all recipe blocks: each starts with "name: org.openrewrite.quarkus.MigrateToQuarkus_vX_Y_Z"
-        Pattern recipePattern = Pattern.compile(
-                "name: (org\\.openrewrite\\.quarkus\\.MigrateToQuarkus_v(\\d+_\\d+_\\d+))");
-        Matcher matcher = recipePattern.matcher(content);
+        // A project on quarkus-bom 3.17.0 should NOT be modified by MigrateToQuarkus_v3_17_0,
+        // because the precondition version: (,3.17.0) excludes 3.17.0 itself
+        List<SourceFile> sources = MavenParser.builder().build().parse(
+                new InMemoryExecutionContext(Throwable::printStackTrace),
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>test</artifactId>
+                            <version>1.0</version>
+                            <dependencyManagement>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>io.quarkus.platform</groupId>
+                                        <artifactId>quarkus-bom</artifactId>
+                                        <version>3.17.0</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                </dependencies>
+                            </dependencyManagement>
+                        </project>
+                        """).toList();
 
-        int recipeCount = 0;
-        while (matcher.find()) {
-            String recipeName = matcher.group(1);
-            String expectedVersion = matcher.group(2).replace("_", ".");
+        RecipeRun result = recipe.run(
+                new org.openrewrite.internal.InMemoryLargeSourceSet(sources),
+                new InMemoryExecutionContext(Throwable::printStackTrace));
 
-            // Find the block for this recipe (from this name: to the next --- or end of file)
-            int blockStart = matcher.start();
-            int blockEnd = content.indexOf("\n---", blockStart);
-            if (blockEnd == -1) {
-                blockEnd = content.length();
-            }
-            String block = content.substring(blockStart, blockEnd);
-
-            assertThat(block)
-                    .as("Recipe %s should have ModuleHasDependency precondition", recipeName)
-                    .contains("org.openrewrite.java.dependencies.search.ModuleHasDependency:");
-            assertThat(block)
-                    .as("Recipe %s should check io.quarkus.platform group", recipeName)
-                    .contains("groupIdPattern: io.quarkus.platform");
-            assertThat(block)
-                    .as("Recipe %s should check quarkus-bom artifact", recipeName)
-                    .contains("artifactIdPattern: quarkus-bom");
-            assertThat(block)
-                    .as("Recipe %s should have version range (,%s)", recipeName, expectedVersion)
-                    .contains("version: (," + expectedVersion + ")");
-
-            recipeCount++;
-        }
-
-        assertThat(recipeCount).as("Should have found multiple recipes in consolidated YAML").isGreaterThan(1);
+        assertThat(result.getChangeset().getAllResults())
+                .as("MigrateToQuarkus_v3_17_0 should not modify a project already on quarkus-bom 3.17.0")
+                .isEmpty();
     }
 }


### PR DESCRIPTION
## Summary

- Fixes https://github.com/moderneinc/customer-requests/issues/2147

- Adds `ModuleHasDependency` preconditions to generated Quarkus aggregation recipes so each migration step only runs when the project's Quarkus version is below the target version
- Precondition uses `io.quarkus:quarkus-core` with version range `(,X.Y.Z)` (exclusive upper bound) — this is a resolved transitive dependency in all Quarkus projects whose version matches the BOM
- Note: `io.quarkus.platform:quarkus-bom` cannot be used because `ModuleHasDependency` only checks resolved dependencies, not BOM imports in `<dependencyManagement>`
- Regenerates `quarkus-consolidated.yml` with preconditions on all 29 versioned recipes
- Changes `rewrite-maven` from `testImplementation` to `testCompileOnly` (already available transitively at runtime)

## Test plan

- [x] `AggregateQuarkusUpdatesTest` verifies generated YAML includes correct precondition structure
- [x] `QuarkusPreconditionTest.doesNotRunWhenQuarkusVersionIsAtTarget` — loads real consolidated recipe, runs against a project on quarkus-bom 3.0.0.Final with a javax dependency, asserts no changes
- [x] `QuarkusPreconditionTest.runsWhenQuarkusVersionIsBelowTarget` — same recipe against quarkus-bom 2.16.12.Final, asserts javax→jakarta migration does produce changes