### PR TITLE
Renew quarkus-update-recipes suppression to 2026-06-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
    file name: quarkus-update-recipes-1.0.19.jar
        sev: HIGH


### PR DESCRIPTION
## Summary

The CPE-based suppression for `io.quarkus:quarkus-update-recipes` expired on 2026-05-01, causing the artifact's recipe-reference CVEs to flag as CRITICAL again.

The artifact only carries Quarkus migration recipe references, not the vulnerable Quarkus runtime — the existing reasoning still holds. Renewed `until="2026-06-01Z"`.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1054

## Test plan
- [x] xmllint validates suppressions.xml
- [ ] Next dependency-check scan no longer flags quarkus-update-recipes CVEs