### PR TITLE
Add marketplace category descriptions for Picnic, Quarkus, and Apache

### DIFF
--- a/src/main/resources/META-INF/rewrite/categories.yml
+++ b/src/main/resources/META-INF/rewrite/categories.yml
@@ -1,0 +1,31 @@
+#
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/category
+name: Picnic
+packageName: tech.picnic
+description: Opinionated Refaster-based recipes from [Picnic's error-prone-support](https://github.com/PicnicSupermarket/error-prone-support) project.
+---
+type: specs.openrewrite.org/v1beta/category
+name: Quarkus
+packageName: io.quarkus
+description: Recipes for upgrading and patching [Quarkus](https://quarkus.io/) applications.
+---
+type: specs.openrewrite.org/v1beta/category
+name: Apache
+packageName: org.apache
+description: Recipes for upgrading [Apache](https://apache.org/) projects such as Camel and Wicket.


### PR DESCRIPTION
Adds an OpenRewrite category descriptor file so the recipe marketplace renders tag lines under the Picnic, Quarkus, and Apache tiles (previously empty). Categories are bound to the `tech.picnic`, `io.quarkus`, and `org.apache` package roots shared by the bundled third-party recipes.