### PR TITLE
Add rewrite-migrate-java to runtime classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     runtimeOnly("org.openrewrite:rewrite-java")
     runtimeOnly("org.openrewrite:rewrite-templating:${rewriteVersion}")
+    runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:${rewriteVersion}")
 
     // Timefold 2.x requires Java 21
     runtimeOnly("ai.timefold.solver:timefold-solver-migration:1.+") {


### PR DESCRIPTION
## Summary
- Adds `org.openrewrite.recipe:rewrite-migrate-java` as a `runtimeOnly` dependency so Axon's `UpgradeJava` recipe can resolve `UpgradeJavaVersion` during classpath scanning.
- Fixes `NoClassDefFoundError` in `QuarkusPreconditionTest` (and any other test invoking `Environment.builder().scanRuntimeClasspath()`).

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.recipe.quarkus.internal.QuarkusPreconditionTest"`