### PR TITLE
Renew expired OWASP suppressions to 2026-07-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
    file name: quarkus-update-recipes-1.0.19.jar
        sev: HIGH


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1085

The `quarkus-update-recipes` CPE suppression (`cpe:/a:quarkus:quarkus`) expired on 2026-06-01 and the CRITICAL quarkus advisories resurfaced in the 2026-06-03 OpenRewrite vulnerability report. `quarkus-update-recipes` is an OpenRewrite recipe JAR and does not contain the vulnerable Quarkus runtime — the match is on the CPE name only. Renewed to `2026-07-01Z`.