### PR TITLE
Pin org.axonframework to 4.+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,8 @@ dependencies {
     runtimeOnly("io.quarkus:quarkus-update-recipes:latest.release") { isTransitive = false }
     runtimeOnly("org.apache.camel.upgrade:camel-upgrade-recipes:latest.release") { isTransitive = false }
     runtimeOnly("org.apache.wicket:wicket-migration:latest.release") { isTransitive = false }
-    runtimeOnly("org.axonframework:axon-migration:latest.release") { isTransitive = false }
+    // Pinned to 4.x: axon-migration 5.x ships classes compiled for Java 21 (class file v65)
+    runtimeOnly("org.axonframework:axon-migration:4.+") { isTransitive = false }
     runtimeOnly("software.amazon.awssdk:v2-migration:latest.release")
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:${rewriteVersion}:recipes") {
         exclude(module = "refaster-support")


### PR DESCRIPTION
## What's changed?

Pinning the `openrewrite/gh-automation` to 4.x.

## What's your motivation?

5.x requires Java 21 and loading the artifact in the Moderne SaaS v1 fails with:
```
Caused by: java.lang.UnsupportedClassVersionError: org/axonframework/migration/MigrateSequencingPolicyLambda has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.
```