### PR TITLE
Shade AWS SDK supporting modules into the fat jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,10 @@ tasks.withType<ShadowJar> {
         include(dependency("org.apache.camel.upgrade:camel-upgrade-recipes"))
         include(dependency("org.apache.wicket:wicket-migration"))
         include(dependency("org.axonframework:axon-migration"))
-        include(dependency("software.amazon.awssdk:v2-migration"))
+        // v2-migration's recipe classes reference its supporting modules (utils, sdk-core, auth,
+        // aws-core, http-client-spi, regions). Since these deps are `provided` (not runtimeOnly),
+        // they no longer reach consumers transitively, so they must be shaded in too.
+        include(dependency("software.amazon.awssdk:.*"))
         include(dependency("tech.picnic.error-prone-support:error-prone-contrib"))
     }
     // Only include eclipse-collections content from liftwizard-rewrite


### PR DESCRIPTION
## What's changed?

Broaden the `shadowJar` include filter for AWS SDK from just `software.amazon.awssdk:v2-migration` to the whole `software.amazon.awssdk:.*` group, so the supporting modules the recipe classes need (`utils`, `sdk-core`, `auth`, `aws-core`, `http-client-spi`, `regions`) are bundled into the fat jar.

## What's your motivation?

- #81 moved the shaded recipe libraries to `provided` scope so consumers no longer re-resolve a second standalone copy of their category descriptors. That's correct, but for `v2-migration` it had a side effect: its supporting modules used to reach consumers transitively (it was `runtimeOnly` with transitives), and `provided` dependencies are not resolved transitively by consumers. The `shadowJar` only bundled the top-level `v2-migration` artifact, so its recipe classes were left referencing AWS SDK classes that are no longer on any consumer classpath.

This surfaced when running `rewrite-recipe-markdown-generator` (e.g. in `moderne-docs`):

```
Caused by: java.lang.NoClassDefFoundError: software/amazon/awssdk/utils/ImmutableMap
	at software.amazon.awssdk.v2migration.V1SetterToV2.<clinit>(V1SetterToV2.java:51)
	...
	at software.amazon.awssdk.v2migration.NewClassToBuilderPattern.getRecipeList(NewClassToBuilderPattern.java:60)
	at org.openrewrite.Recipe.createRecipeDescriptor(Recipe.java:236)
```

The `provided` scope (and the de-duplication it fixes) is preserved; this only makes the fat jar self-contained for AWS SDK, restoring the classes that previously reached consumers transitively.

## Validation

Built the fat jar before and after, and initialized the recipe classes from the stack trace against a consumer-style classpath (fat jar + the published runtime deps, which excludes the `provided` AWS SDK jars):

- **Before:** `NoClassDefFoundError: software/amazon/awssdk/utils/ImmutableMap` (matches the report)
- **After:** `V1SetterToV2` and `NewClassToBuilderPattern` initialize cleanly

Checked the other transitive shaded libraries too: `timefold-solver-migration`'s recipe classes only reference `org.slf4j` (provided by the platform), and `error-prone-contrib`'s dependencies are `provided` in its own POM and already handled via `recipeDependencies`, so neither is similarly affected.